### PR TITLE
Fixes a typo in a defvar that causes a compiler warning.

### DIFF
--- a/clean-aindent-mode.el
+++ b/clean-aindent-mode.el
@@ -275,7 +275,7 @@ align with that smaller indentation"
 ;;
 
 (defvar clean-aindent--last-indent nil)
-(defvar clean-aindent--last-indent-length 0)
+(defvar clean-aindent--last-indent-len 0)
 
 (defvar clean-aindent-mode--keymap (make-keymap) "clean-aindent-mode keymap.")
 (define-key clean-aindent-mode--keymap (kbd "M-DEL") 'clean-aindent--bsunindent)


### PR DESCRIPTION
Hi, I kept getting a compiler warning about assignment to a free variable `clean-aindent--last-indent-len` and this seems to be the typo that causes the problem. 